### PR TITLE
Don't load Ruby 1.8.x compatibility library for Ruby 2.1.8.

### DIFF
--- a/lib/s3cp/utils.rb
+++ b/lib/s3cp/utils.rb
@@ -16,7 +16,7 @@
 # the License.
 
 require 'rubygems'
-require 'extensions/kernel' if RUBY_VERSION =~ /1.8/
+require 'extensions/kernel' if RUBY_VERSION =~ /^1.8/
 require 'aws/s3'
 require 'optparse'
 require 'date'


### PR DESCRIPTION
When run on Ruby 2.1.8, s3cp/utils.rb was incorrectly loading code intended for Ruby 1.8. This causes an error:

```
extensions-0.6.0/lib/extensions/_base.rb:150:in `<top (required)>': uninitialized constant VERSION (NameError)
```

since VERSION is only defined in Ruby < 1.9.