### PR TITLE
Relax nokogiri dependency, allowing >= 1.6.0 and < 1.7.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       aws-sdk (~> 1.63.0)
       extensions (~> 0.6)
       highline (>= 1.5.1)
-      nokogiri (~> 1.6.6.2)
+      nokogiri (~> 1.6.6)
       progressbar (~> 0.10.0)
 
 GEM

--- a/s3cp.gemspec
+++ b/s3cp.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency("highline", [">= 1.5.1"])
   s.add_dependency("aws-sdk", ["~> 1.63.0"])
   s.add_dependency("progressbar", ["~> 0.10.0"])
-  s.add_dependency("nokogiri", ["~> 1.6.6.2"])
+  s.add_dependency("nokogiri", ["~> 1.6.6"])
 
   s.add_development_dependency("rspec", ["~> 2.5.0"])
   s.add_development_dependency("rake", ["~> 0.8.7"])


### PR DESCRIPTION
This allows use of nokigiri 1.6.7.x, which is the currently-maintained series for security fixes.
